### PR TITLE
fix: Enable 'full' on syn when 'serde' feature-gate is enabled

### DIFF
--- a/int-enum-impl/Cargo.toml
+++ b/int-enum-impl/Cargo.toml
@@ -26,5 +26,5 @@ default = [] # default features are applied by parent crate
 
 std = []
 
-serde = []
+serde = ["syn/full"]
 convert = []


### PR DESCRIPTION
I get the following error:

```rust
error[E0432]: unresolved import `syn::ItemFn`
  --> int-enum-impl/src/serde.rs:19:33
   |
19 |     use syn::{Attribute, Ident, ItemFn};
   |                                 ^^^^^^ no `ItemFn` in the root
 ```

when I run:

```bash
cargo test --features serde
```

As mentioned in the latest [syn crate](https://docs.rs/syn/latest/syn/struct.ItemFn.html) that `ItemFn` is available on `full` feature-gate.

This pull request fixes the aforementioned error.