### PR TITLE
Fix name of feature in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use self::int::PrimInt;
 /// # }
 /// ```
 ///
-/// Serde support (requires feature `serialize`):
+/// Serde support (requires feature `serde`):
 ///
 /// ```
 /// # use std::error::Error;


### PR DESCRIPTION
Currently, following the documentation leads to the following error:
```
depends on `int-enum`, with features: `serialize` but `int-enum` does not have these features.
```

If we instead use `serde` it works as expected. See excerpt from `Cargo.toml`:
```
[dependencies]
int-enum = {version = "0.5.0", features=["serde"]}
```